### PR TITLE
Refactor: migrate project to uv package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.12
 
-COPY requirements.txt /srv/requirements.txt
 WORKDIR /srv
-RUN python -m pip install --upgrade pip && python -m pip install --no-cache-dir -r requirements.txt
+
+# Install uv
+RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- 
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install dependencies
+COPY requirements.txt /srv/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/requirements.txt

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ Start by creating the required folder structure:
 ```bash
 make prepare-dirs
 ```
-Then, download the dataset using the automated script:
+
+Then spin up the full development environment to make sure all required services (Postgres, MinIO, MLflow, Grafana, etc.) are up and running:
+
+```bash
+make run-dev
+```
+
+This will start the local stack defined in docker-compose.yml and ensure all components are available for the subsequent steps.  
+Once the containers are running, you can proceed with downloading the dataset using the automated script.
 
 ```bash
 make download-data

--- a/services/ci/Dockerfile
+++ b/services/ci/Dockerfile
@@ -1,10 +1,18 @@
 FROM python:3.12
 
-COPY services/production/requirements.txt /srv/requirements.txt
+WORKDIR /srv
+
+# Install uv
+RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- 
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install dependencies
+COPY services/production/requirements.txt  /srv/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/requirements.txt
+
 COPY data_store/prod_model.cbm /srv/data/prod_model.cbm
 COPY src/ /srv/src/
-
-WORKDIR /srv
-RUN python -m pip install --upgrade pip && python -m pip install --no-cache-dir -r requirements.txt
 
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8090", "--reload"]

--- a/services/ci/requirements.txt
+++ b/services/ci/requirements.txt
@@ -1,9 +1,0 @@
-catboost==1.2.5
-numpy==1.26.4
-pandas==2.2.2
-PyYAML==6.0.1
-fastapi==0.111.0
-uvicorn[standard]==0.29.0
-pydantic==2.11.7
-pytest==8.2.2
-httpx==0.27.0

--- a/services/jupyter/Dockerfile
+++ b/services/jupyter/Dockerfile
@@ -2,20 +2,17 @@ FROM python:3.12-slim
 
 WORKDIR /srv
 
-# Install system dependencies
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    build-essential \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-# Install uv for fast Python package installation
-RUN pip install --no-cache-dir uv
+# Install uv
+RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- 
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Install base dependencies (cached layer)
-COPY base-requirements.txt /srv/base-requirements.txt
-RUN uv pip install --system --no-cache -r /srv/base-requirements.txt
+COPY services/jupyter/base-requirements.txt /srv/base-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/base-requirements.txt
 
 # Install project-specific dependencies
-COPY requirements.txt /srv/requirements.txt
-RUN uv pip install --system --no-cache -r /srv/requirements.txt
+COPY services/jupyter/requirements.txt /srv/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/requirements.txt

--- a/services/mlflow/Dockerfile
+++ b/services/mlflow/Dockerfile
@@ -1,10 +1,20 @@
 FROM python:3.12
 
-COPY requirements.txt /srv/requirements.txt
 WORKDIR /srv
-RUN python -m pip install --upgrade pip && python -m pip install --no-cache-dir -r requirements.txt 
+
+# Install uv
+RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- 
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Copy deps early to leverage layer cache
+COPY services/mlflow/requirements.txt /srv/requirements.txt
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/requirements.txt
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/services/production/Dockerfile
+++ b/services/production/Dockerfile
@@ -1,10 +1,18 @@
 FROM python:3.12
 
+WORKDIR /srv
+
+# Install uv
+RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- 
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Install dependencies
 COPY services/production/requirements.txt /srv/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r /srv/requirements.txt
+
 COPY data_store/prod_model.cbm /srv/data/prod_model.cbm
 COPY src/ /srv/src/
-
-WORKDIR /srv
-RUN python -m pip install --upgrade pip && python -m pip install --no-cache-dir -r requirements.txt
 
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8090", "--reload"]


### PR DESCRIPTION
- Replaced pip with uv in all Dockerfiles (root, jupyter, mlflow, production, ci)
- Removed redundant services/ci/requirements.txt
- Updated README.md add missed starting docker dev